### PR TITLE
Add prototype for SQL learning game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Interactive SQL Learning Game
+
+This repository contains a minimal prototype for an interactive SQL-learning game. It is split into two folders:
+
+- `client` – React + TypeScript frontend
+- `server` – NestJS backend with MySQL via TypeORM
+
+The example demonstrates how scenarios can be presented and how user progress could be stored.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,8 @@
+# SQL Learning Game Frontend
+
+A simple React + TypeScript frontend for the SQL learning game. It demonstrates a scenario with a textarea-based SQL editor and basic routing.
+
+## Available Scripts
+
+- `npm start` - start a development build (requires webpack)
+- `npm run build` - build for production

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "sql-learning-client",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.0",
+    "typescript": "^5.0.2"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SQL Learning Game</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import ScenarioPage from './pages/ScenarioPage';
+import Dashboard from './pages/Dashboard';
+
+const App: React.FC = () => (
+  <div>
+    <nav>
+      <Link to="/">Home</Link> | <Link to="/dashboard">Dashboard</Link>
+    </nav>
+    <Routes>
+      <Route path="/" element={<ScenarioPage />} />
+      <Route path="/dashboard" element={<Dashboard />} />
+    </Routes>
+  </div>
+);
+
+export default App;

--- a/client/src/components/SqlEditor.tsx
+++ b/client/src/components/SqlEditor.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+}
+
+const SqlEditor: React.FC<Props> = ({ value, onChange }) => {
+  return (
+    <textarea
+      style={{ width: '100%', height: '150px' }}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+};
+
+export default SqlEditor;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container!);
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Dashboard: React.FC = () => {
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <p>Your progress will appear here.</p>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/client/src/pages/ScenarioPage.tsx
+++ b/client/src/pages/ScenarioPage.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import SqlEditor from '../components/SqlEditor';
+
+const sampleScenario = {
+  id: '1',
+  title: 'Music Store',
+  description: "You're a junior data analyst at a music store. Retrieve all songs from the 'Pop' genre sorted by popularity.",
+  solutionQuery: 'SELECT * FROM songs WHERE genre = \"Pop\" ORDER BY popularity DESC;'
+};
+
+const ScenarioPage: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+
+  const checkAnswer = () => {
+    const cleaned = query.replace(/\s+/g, ' ').trim().toLowerCase();
+    const solution = sampleScenario.solutionQuery.replace(/\s+/g, ' ').trim().toLowerCase();
+    if (cleaned === solution) {
+      setResult('correct');
+    } else {
+      setResult('incorrect');
+    }
+  };
+
+  return (
+    <div>
+      <h2>{sampleScenario.title}</h2>
+      <p>{sampleScenario.description}</p>
+      <SqlEditor value={query} onChange={setQuery} />
+      <button onClick={checkAnswer}>Run Query</button>
+      {result === 'correct' && <p style={{ color: 'green' }}>Correct!</p>}
+      {result === 'incorrect' && <p style={{ color: 'red' }}>Try again.</p>}
+    </div>
+  );
+};
+
+export default ScenarioPage;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,9 @@
+# SQL Learning Game Backend
+
+This is a minimal NestJS backend for the SQL learning game. It exposes authentication and progress tracking endpoints and uses MySQL via TypeORM.
+
+## Available Scripts
+
+- `npm start` - start the development server
+
+Database connection settings are configured in `src/app.module.ts` and use a local MySQL instance.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "sql-learning-server",
+  "version": "0.1.0",
+  "description": "Backend for SQL learning game",
+  "scripts": {
+    "start": "nest start"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "bcrypt": "^5.0.1",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.12",
+    "mysql2": "^2.3.3"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "typescript": "^5.0.2"
+  }
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
+import { ProgressModule } from './progress/progress.module';
+import { User } from './entities/user.entity';
+import { Scenario } from './entities/scenario.entity';
+import { UserProgress } from './entities/user-progress.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'mysql',
+      host: 'localhost',
+      port: 3306,
+      username: 'root',
+      password: 'password',
+      database: 'sql_learning',
+      entities: [User, Scenario, UserProgress],
+      synchronize: true,
+    }),
+    AuthModule,
+    ProgressModule,
+  ],
+})
+export class AppModule {}

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Post, Body, UnauthorizedException } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private authService: AuthService) {}
+
+  @Post('register')
+  async register(@Body() body: { username: string; email: string; password: string }) {
+    const token = await this.authService.register(body.username, body.email, body.password);
+    return { token };
+  }
+
+  @Post('login')
+  async login(@Body() body: { username: string; password: string }) {
+    const user = await this.authService.validateUser(body.username, body.password);
+    if (!user) throw new UnauthorizedException();
+    const token = await this.authService.login(user);
+    return { token };
+  }
+}

--- a/server/src/auth/auth.module.ts
+++ b/server/src/auth/auth.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { User } from '../entities/user.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    PassportModule,
+    JwtModule.register({
+      secret: 'secret',
+      signOptions: { expiresIn: '1d' },
+    }),
+  ],
+  providers: [AuthService],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../entities/user.entity';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User) private users: Repository<User>,
+    private jwtService: JwtService,
+  ) {}
+
+  async register(username: string, email: string, password: string) {
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = this.users.create({ username, email, passwordHash });
+    await this.users.save(user);
+    return this.jwtService.sign({ sub: user.id });
+  }
+
+  async validateUser(username: string, password: string) {
+    const user = await this.users.findOne({ where: { username } });
+    if (!user) return null;
+    const ok = await bcrypt.compare(password, user.passwordHash);
+    if (ok) return user;
+    return null;
+  }
+
+  async login(user: User) {
+    return this.jwtService.sign({ sub: user.id });
+  }
+}

--- a/server/src/entities/scenario.entity.ts
+++ b/server/src/entities/scenario.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('scenarios')
+export class Scenario {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column('text')
+  description: string;
+
+  @Column('text')
+  solutionQuery: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/server/src/entities/user-progress.entity.ts
+++ b/server/src/entities/user-progress.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+import { Scenario } from './scenario.entity';
+
+@Entity('user_progress')
+export class UserProgress {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Scenario)
+  @JoinColumn({ name: 'scenario_id' })
+  scenario: Scenario;
+
+  @Column('text')
+  userQuery: string;
+
+  @Column()
+  isCorrect: boolean;
+
+  @CreateDateColumn()
+  attemptedAt: Date;
+}

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  username: string;
+
+  @Column({ unique: true })
+  email: string;
+
+  @Column()
+  passwordHash: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/server/src/progress/progress.controller.ts
+++ b/server/src/progress/progress.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Post, Body, Get, Param } from '@nestjs/common';
+import { ProgressService } from './progress.service';
+
+@Controller('progress')
+export class ProgressController {
+  constructor(private progressService: ProgressService) {}
+
+  @Post()
+  async save(@Body() body: { userId: string; scenarioId: string; userQuery: string; isCorrect: boolean }) {
+    return this.progressService.saveProgress(body.userId, body.scenarioId, body.userQuery, body.isCorrect);
+  }
+
+  @Get(':userId')
+  async get(@Param('userId') userId: string) {
+    return this.progressService.getProgress(userId);
+  }
+}

--- a/server/src/progress/progress.module.ts
+++ b/server/src/progress/progress.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProgressService } from './progress.service';
+import { ProgressController } from './progress.controller';
+import { UserProgress } from '../entities/user-progress.entity';
+import { Scenario } from '../entities/scenario.entity';
+import { User } from '../entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserProgress, Scenario, User])],
+  providers: [ProgressService],
+  controllers: [ProgressController],
+})
+export class ProgressModule {}

--- a/server/src/progress/progress.service.ts
+++ b/server/src/progress/progress.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserProgress } from '../entities/user-progress.entity';
+import { Scenario } from '../entities/scenario.entity';
+import { User } from '../entities/user.entity';
+
+@Injectable()
+export class ProgressService {
+  constructor(
+    @InjectRepository(UserProgress) private progressRepo: Repository<UserProgress>,
+    @InjectRepository(Scenario) private scenarioRepo: Repository<Scenario>,
+    @InjectRepository(User) private userRepo: Repository<User>,
+  ) {}
+
+  async saveProgress(userId: string, scenarioId: string, userQuery: string, isCorrect: boolean) {
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    const scenario = await this.scenarioRepo.findOne({ where: { id: scenarioId } });
+    const progress = this.progressRepo.create({ user, scenario, userQuery, isCorrect });
+    return this.progressRepo.save(progress);
+  }
+
+  async getProgress(userId: string) {
+    return this.progressRepo.find({ where: { user: { id: userId } }, relations: ['scenario'] });
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up frontend (React + TypeScript) with a sample scenario page and dashboard
- set up backend (NestJS) with auth and progress modules using TypeORM
- provide minimal entities for users, scenarios and progress
- add READMEs for the project and each subfolder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859bbb3e23083268474a9719852b90f